### PR TITLE
struct base SYSCALLs passing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use alloc::sync::Arc;
 use crate::thread::switch;
 use crate::drivers::Driver;
 use crate::interrupt::{enable_irq};
-use crate::syscalls::UKern;
+use crate::syscalls::UKERN;
 
 #[no_mangle]
 pub static mut cpu1_stack: u32 = 0;
@@ -72,8 +72,6 @@ static mut AP_INIT_STACK: *mut usize = 0x0 as *mut usize;
 
 /// Stack size for the kernel main thread
 const KERNEL_STACK_SIZE: usize = 4096 * 16;
-
-static ukern : UKern = UKern {};
 
 #[allow(dead_code)]
 static PAGER: Mutex<BespinSlabsProvider> = Mutex::new(BespinSlabsProvider::new());
@@ -181,7 +179,7 @@ pub fn init_allocator() {
 
 fn init_user() {
     //crate::thread::create_thread("init", usr::init::init); 
-    usr::init::init(ukern); 
+    usr::init::init(UKERN); 
 }
 
 const MAX_CPUS: u32 = 32;

--- a/src/syscalls.rs
+++ b/src/syscalls.rs
@@ -3,11 +3,6 @@ use crate::thread::{do_yield, create_thread};
 use usr::capabilities::Capability;
 use usr::syscalls::Syscall;
 
-#[derive(Clone, Copy, PartialEq)]
-pub struct UKern {
-
-}
-
 // Print a string 
 pub fn sys_print(s: &str) {
 
@@ -37,19 +32,9 @@ pub fn sys_create_thread(name: &str, func: extern fn()) -> Capability  {
 }
 
 
-
-impl Syscall for UKern {
-    fn sys_print(&self, s: &str) {
-        sys_print(s);   
-    }
-
-    fn sys_yield(&self) {
-        sys_yield();
-    }
-
-    fn sys_create_thread(&self, name: &str, func: extern fn()) -> Capability {
-        return sys_create_thread(name, func); 
-    }
-
-}
+pub static UKERN: Syscall = Syscall{
+    sys_print,
+    sys_yield,
+    sys_create_thread,
+};
 

--- a/usr/Cargo.toml
+++ b/usr/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Anton Burtsev <aburtsev@uci.edu>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+spin = "0.5.2"
 
 #[dev-dependencies]
 #redleaf = { path = "../", version = "0.1.0" }

--- a/usr/src/init.rs
+++ b/usr/src/init.rs
@@ -1,25 +1,31 @@
 //extern crate redleaf;
 
 //use redleaf::syscalls::{sys_create_thread, sys_print};
+use spin::Once;
 use crate::syscalls::{Syscall};
 
-pub extern fn init(s: impl Syscall) {
-    s.sys_print("init userland");
-    s.sys_create_thread("hello1", hello1); 
-    s.sys_create_thread("hello2", hello2); 
+static SYSCALL: Once<Syscall> = Once::new();
+
+pub extern fn init(s: Syscall) {
+    SYSCALL.call_once(|| s);
+    (s.sys_print)("init userland");
+    (s.sys_create_thread)("hello1", hello1); 
+    (s.sys_create_thread)("hello2", hello2); 
 }
 
 
 pub extern fn hello1() {
+    let s = SYSCALL.r#try().expect("Userland is not initialized.");
     loop {
-        //sys_print("hello 1"); 
-        //sys_yield();
+        (s.sys_print)("hello 1"); 
+        (s.sys_yield)();
     }
 }
 
 pub extern fn hello2() {
+    let s = SYSCALL.r#try().expect("Userland is not initialized.");
     loop {
-        //sys_print("hello 2"); 
+        (s.sys_print)("hello 2"); 
     }
 }
 

--- a/usr/src/syscalls.rs
+++ b/usr/src/syscalls.rs
@@ -1,8 +1,9 @@
 use crate::capabilities::Capability; 
 
-pub trait Syscall {
-    fn sys_print(&self, s: &str);
-    fn sys_yield(&self);
-    fn sys_create_thread(&self, name: &str, func: extern fn()) -> Capability;
+#[derive(Copy, Clone)]
+pub struct Syscall {
+    pub sys_print: fn(s: &str),
+    pub sys_yield: fn(),
+    pub sys_create_thread: fn(name: &str, func: extern fn()) -> Capability,
 }
 


### PR DESCRIPTION
Passing the syscall interfaces to the userland by a struct so we can store it in a static immutable object using `spin::Once`