### PR TITLE
Add pre-requisite dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ sudo apt-get install qemu
 sudo apt-get install nasm
 ```
 
+* Install Grub
+
+```
+apt-get install grub-pc-bin
+```
+
 ### Run
 
 ```


### PR DESCRIPTION
Qemu won't be able to load and returns an error (`Could not read from CDROM (code 0009)`) if the packet is not installed 